### PR TITLE
Add LeetCode Problem 130: Surrounded Regions to Problem Set

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,15 @@
 export const data = [
   {
+    "Id": 126,
+    "Solution": "https://github.com/vivekchand/grind169-solutions/blob/main/130.%20Surrounded%20Regions/SurroundedRegions.java",
+    "Url": "https://leetcode.com/problems/surrounded-regions/",
+    "Week": 11,
+    "Category": "Graph",
+    "Problem": "Surrounded Regions",
+    "Summary": "This solution uses DFS to mark 'O's that are not surrounded by 'X's. It starts from the border 'O's and marks all connected 'O's as 'E'. Then it traverses the entire board, changing remaining 'O's to 'X's and 'E's back to 'O's.",
+    "Type": "Medium"
+  },
+  {
     "Id": 1,
     "Solution": "https://github.com/vivekchand/grind169-solutions/blob/main/1.%20Two%20Sum/TwoSum.java",
     "Url": "https://leetcode.com/problems/two-sum/",


### PR DESCRIPTION
# Summary of Changes
This pull request adds LeetCode problem 130 "Surrounded Regions" to our existing problem set in the `config.js` file.

## Details
- Added a new entry to the `data` array in `src/config.js`
- New problem details:
  - Id: 126
  - Problem: Surrounded Regions
  - LeetCode URL: https://leetcode.com/problems/surrounded-regions
  - Difficulty: Medium
  - Category: Graph
  - Week: 11
  - Summary: "Use DFS or BFS to mark 'O's on the border and those connected to them. Then, iterate through the board to flip unmarked 'O's to 'X's."

## Motivation
This addition expands our collection of medium-difficulty graph problems, providing more practice opportunities for users working on graph traversal algorithms.

## Potential Impacts
- Users will see this new problem in the Week 11 section of the problem set
- The total count of problems will increase by one

## Testing
Please verify that:
1. The new problem appears correctly in the UI
2. The problem details are accurate and complete
3. The problem is correctly categorized as "Medium" difficulty

Let me know if any further changes or information are needed.